### PR TITLE
Fix: Setting::has('non-existent') behaviour

### DIFF
--- a/src/Philf/Setting/interfaces/LaravelFallbackInterface.php
+++ b/src/Philf/Setting/interfaces/LaravelFallbackInterface.php
@@ -22,6 +22,13 @@ class LaravelFallbackInterface implements FallbackInterface {
      */
     public function fallbackHas($key)
     {
-        return \App::make('config')->has($key);
+        $settingExists = \App::make('config')->has($key);
+
+        $setting = \App::make('config')->get($key);
+        if (is_array($setting) and count($setting) == 0) {
+            return false;
+        }
+
+        return $settingExists;
     }
 }


### PR DESCRIPTION
This would Fix: [#23](https://github.com/Phil-F/Setting/issues/24)

When asking if Setting has some non existent key it always returned `true`. This behaviour comes directly from laravel `Config`. This change adds a workaround to add the correct behaviour, so `Setting::has('non-existent')` will now return `false` as expected.